### PR TITLE
.gitignore file added 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Mac.
+.DS_STORE
+
+# Node.
+node_modules
+debug.log
+
+# TS after compilation files
+app.component.js
+app.component.js.map
+app.module.js
+app.module.js.map
+main.js.map
+main.js
+welcome.component.js
+welcome.component.js.map
+index.d.TS
+typings.json


### PR DESCRIPTION
.gitignore file added to avoid node_modules folder and 
other unwanted after compilation files to be added in github repository
